### PR TITLE
rescue Exception --> rescue LoadError

### DIFF
--- a/lib/migration_comments.rb
+++ b/lib/migration_comments.rb
@@ -37,7 +37,7 @@ module MigrationComments
         unless adapter_class.descendants.include?(mc_class)
           adapter_class.prepend mc_class
         end
-      rescue Exception => ex
+      rescue ::LoadError
       end
     end
 
@@ -50,7 +50,7 @@ module MigrationComments
       unless gem_class.ancestors.include?(mc_class)
         gem_class.prepend mc_class
       end
-    rescue Exception => ex
+    rescue ::LoadError
       # if we got here, don't bother installing comments into annotations
     end
   end


### PR DESCRIPTION
Rescuing from `Exception` is dangerous when not rethrown. In this case, a more specific class can be used. This PR uses the `LoadError` class, which has `Gem::LoadError` (the actual exception that is thrown) and `Gem::ConflictError` for descendants. 

Rational for this PR here: http://stackoverflow.com/a/10048406/80636
